### PR TITLE
filename for def file now works on Windows

### DIFF
--- a/lib/rltk/parser.rb
+++ b/lib/rltk/parser.rb
@@ -548,7 +548,7 @@ module RLTK # :nodoc:
 				opts = self.build_finalize_opts(opts)
 				
 				# Get the name of the file in which the parser is defined.
-				def_file = caller()[2].split(':')[0]
+				def_file = caller()[2].match("(.*):([0-9]+):.*")[1]
 				
 				# Check to make sure we can load the necessary information
 				# from the specified object.


### PR DESCRIPTION
filename on Windows have a drive with a ':' in it. Therefore the original split on ':' doesn't return the expected result. I wrote a regexp which does the trick. Haven't tested on Linux or MacOS b/c I don't those systems.

-st
