### PR TITLE
Subclass StandardError instead of Exception.

### DIFF
--- a/README
+++ b/README
@@ -271,8 +271,8 @@ If the input (including the +ERROR+ token) can be reduced immediately the associ
 
 The example below for the unit tests shows a very basic usage of error productions:
 
-	class AfterPlsError < Exception; end
-	class AfterSubError < Exception; end
+	class AfterPlsError < StandardError; end
+	class AfterSubError < StandardError; end
 
 	class ErrorCalc < RLTK::Parser
 		production(:e) do

--- a/lib/rltk/ast.rb
+++ b/lib/rltk/ast.rb
@@ -6,7 +6,7 @@
 module RLTK # :nodoc:
 	# A TypeMismatch is thrown when an object being set as a child or value of
 	# an ASTNode is of the wrong type.
-	class TypeMismatch < Exception
+	class TypeMismatch < StandardError
 		
 		# Instantiates a new TypeMismatch object.  The first argument is the
 		# expected type and the second argument is the actual type of the
@@ -62,13 +62,13 @@ module RLTK # :nodoc:
 						t = type
 						
 					else
-						raise Exception, 'Child and Value types must be a class name or an array with a single class name element.'
+						raise 'Child and Value types must be a class name or an array with a single class name element.'
 					end
 					
 					# Check to make sure that type is a subclass of
 					# ASTNode.
 					if not RLTK::subclass_of?(t, ASTNode)
-						raise Exception, "A child's type specification must be a subclass of ASTNode."
+						raise "A child's type specification must be a subclass of ASTNode."
 					end
 					
 					@child_names << name
@@ -152,13 +152,13 @@ module RLTK # :nodoc:
 						t = type
 						
 					else
-						raise Exception, 'Child and Value types must be a class name or an array with a single class name element.'
+						raise 'Child and Value types must be a class name or an array with a single class name element.'
 					end
 					
 					# Check to make sure that type is NOT a subclass of
 					# ASTNode.
 					if RLTK::subclass_of?(t, ASTNode)
-						raise Exception, "A value's type specification must NOT be a subclass of ASTNode."
+						raise "A value's type specification must NOT be a subclass of ASTNode."
 					end
 					
 					@value_names << name
@@ -201,7 +201,7 @@ module RLTK # :nodoc:
 		# Assigns an array of AST nodes as the children of this node.
 		def children=(children)
 			if children.length != self.class.child_names.length
-				raise Exception, 'Wrong number of children specified.'
+				raise 'Wrong number of children specified.'
 			end
 			
 			self.class.child_names.each_with_index do |name, i|
@@ -247,7 +247,7 @@ module RLTK # :nodoc:
 		# the order they were declared).
 		def initialize(*objects)
 			if self.class == RLTK::ASTNode
-				raise Exception, 'Attempting to instantiate the RLTK::ASTNode class.'
+				raise 'Attempting to instantiate the RLTK::ASTNode class.'
 			else
 				@notes	= Hash.new()
 				@parent	= nil
@@ -277,7 +277,7 @@ module RLTK # :nodoc:
 		# Assigns an array of objects as the values of this node.
 		def values=(values)
 			if values.length != self.class.value_names.length
-				raise Exception, 'Wrong number of values specified.'
+				raise 'Wrong number of values specified.'
 			end
 			
 			self.class.value_names.each_with_index do |name, i|

--- a/lib/rltk/cfg.rb
+++ b/lib/rltk/cfg.rb
@@ -21,7 +21,7 @@ module RLTK # :nodoc:
 	
 	# An exception class that represents a problem with a context-free
 	# grammar's definition.
-	class GrammarError < Exception; end
+	class GrammarError < StandardError; end
 	
 	# The CFG class is used to represent context-free grammars.  It is used by
 	# the RLTK::Parser class to represent the parser's grammar, but can also be

--- a/lib/rltk/lexer.rb
+++ b/lib/rltk/lexer.rb
@@ -21,7 +21,7 @@ module RLTK # :nodoc:
 	
 	# A LexingError exception is raised when an input stream contains a
 	# substring that isn't matched by any of a lexer's rules.
-	class LexingError < Exception
+	class LexingError < StandardError
 		def initialize(stream_offset, line_number, line_offset, remainder)
 			@stream_offset	= stream_offset
 			@line_number	= line_number

--- a/lib/rltk/parser.rb
+++ b/lib/rltk/parser.rb
@@ -18,7 +18,7 @@ module RLTK # :nodoc:
 	
 	# A BadToken exception indicates that a token was observed in the input
 	# stream that wasn't used in the grammar's definition.
-	class BadToken < Exception
+	class BadToken < StandardError
 		def to_s
 			'Unexpected token.  Token not present in grammar definition.'
 		end
@@ -27,7 +27,7 @@ module RLTK # :nodoc:
 	# A NotInLanguage exception is raised whenever there is no valid parse tree
 	# for a given token stream.  In other words, the input string is not in the
 	# defined language.
-	class NotInLanguage < Exception
+	class NotInLanguage < StandardError
 		def to_s
 			'String not in language.'
 		end
@@ -35,7 +35,7 @@ module RLTK # :nodoc:
 	
 	# An exception of this type is raised when the parser encountered a error
 	# that was handled by an error production.
-	class HandledError < Exception
+	class HandledError < StandardError
 		
 		# The errors as reported by the parser.
 		attr_reader :errors
@@ -51,11 +51,11 @@ module RLTK # :nodoc:
 	end
 	
 	# Used for errors that occure during parser construction.
-	class ParserConstructionError < Exception; end
+	class ParserConstructionError < StandardError; end
 	
 	# Used for runtime errors that are the parsers fault.  These should never
 	# be observed in the wild.
-	class InternalParserError < Exception; end
+	class InternalParserError < StandardError; end
 	
 	# The Parser class may be sub-classed to produce new parsers.  These
 	# parsers have a lot of features, and are described in the main

--- a/test/tc_ast.rb
+++ b/test/tc_ast.rb
@@ -63,8 +63,8 @@ class ASTNodeTester < Test::Unit::TestCase
 	end
 	
 	def test_initialize
-		assert_raise(Exception) { RLTK::ASTNode.new }
-		assert_nothing_raised(Exception) { ANode.new(nil, nil) }
+		assert_raise(RuntimeError) { RLTK::ASTNode.new }
+		assert_nothing_raised(RuntimeError) { ANode.new(nil, nil) }
 	end
 	
 	def test_notes

--- a/test/tc_parser.rb
+++ b/test/tc_parser.rb
@@ -76,8 +76,8 @@ class ArrayCalc < RLTK::Parser
 	finalize
 end
 
-class DummyError1 < Exception; end
-class DummyError2 < Exception; end
+class DummyError1 < StandardError; end
+class DummyError2 < StandardError; end
 
 class ErrorCalc < RLTK::Parser
 	production(:e) do


### PR DESCRIPTION
RLTK should use subclasses of StandardError instead of Exception. Exception is generally reserved for things which are fatal to Ruby itself and most application errors are under StandardError. Plus, the standard `rescue` without any argument catches any subclasses of StandardError, but not of Exception.
