### PR TITLE
Include lib/rltk.rb in gem

### DIFF
--- a/rltk.gemspec
+++ b/rltk.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 			'README.md',
 			'Rakefile',
 			] +
-			Dir.glob('lib/rltk/**/*.rb')
+			Dir.glob('lib/**/*.rb')
 			
 			
 	s.require_path	= 'lib'


### PR DESCRIPTION
Dir.glob('lib/rltk/*_/_.rb') misses the file lib/rltk.rb therefore it isn't included in the gem and cannot be used when installing RLTK as gem.
