### PR TITLE
Support running RLTK on Ruby 1.8.7.

### DIFF
--- a/lib/rltk/ast.rb
+++ b/lib/rltk/ast.rb
@@ -18,7 +18,7 @@ module RLTK # :nodoc:
 	# A TypeMismatch is raised when an object being set as a child or value of
 	# an ASTNode is of the wrong type.
 	class TypeMismatch < StandardError
-		
+
 		# Instantiates a new TypeMismatch object.
 		#
 		# @param [Class] expected	Expected type.
@@ -27,27 +27,27 @@ module RLTK # :nodoc:
 			@expected	= expected
 			@actual	= actual
 		end
-		
+
 		# @return [String] String representation of the error.
 		def to_s
 			"Type Mismatch: Expected #{@expected} but received #{@actual}."
 		end
 	end
-	
+
 	# This class is a good start for all your abstract syntax tree node needs.
 	class ASTNode
 		# @return [ASTNode] Reference to the parent node.
 		attr_accessor :parent
-		
+
 		# @return [Hash] The notes hash for this node.
 		attr_reader :notes
-		
+
 		#################
 		# Class Methods #
 		#################
-		
+
 		class << self
-			
+
 			# Installs instance class varialbes into a class.
 			#
 			# @return [void]
@@ -61,7 +61,7 @@ module RLTK # :nodoc:
 				end
 			end
 			protected :install_icvars
-			
+
 			# Called when the Lexer class is sub-classed, it installes
 			# necessary instance class variables.
 			#
@@ -71,7 +71,7 @@ module RLTK # :nodoc:
 			def inherited(klass)
 				klass.install_icvars
 			end
-			
+
 			# Defined a child for this AST class and its subclasses.
 			# The name of the child will be used to define accessor
 			# methods that include type checking.  The type of this
@@ -84,29 +84,29 @@ module RLTK # :nodoc:
 			def child(name, type)
 				if type.is_a?(Array) and type.length == 1
 					t = type.first
-				
+
 				elsif type.is_a?(Class)
 					t = type
-					
+
 				else
 					raise 'Child and Value types must be a class name or an array with a single class name element.'
 				end
-				
+
 				# Check to make sure that type is a subclass of
 				# ASTNode.
 				if not t.subclass_of?(ASTNode)
 					raise "A child's type specification must be a subclass of ASTNode."
 				end
-				
+
 				@child_names << name
 				define_accessor(name, type, true)
 			end
-			
+
 			# @return [Array<Symbol>] Array of the names of this node class's children.
 			def child_names
 				@child_names
 			end
-			
+
 			# This method defines a type checking accessor named *name*
 			# with type *type*.
 			#
@@ -117,53 +117,53 @@ module RLTK # :nodoc:
 			# @return [void]
 			def define_accessor(name, type, set_parent = false)
 				ivar_name = ('@' + name.to_s).to_sym
-				
+
 				define_method(name) do
 					self.instance_variable_get(ivar_name)
 				end
-				
+
 				if type.is_a?(Class)
 					if set_parent
 						define_method((name.to_s + '=').to_sym) do |value|
 							if value.is_a?(type) or value == nil
 								self.instance_variable_set(ivar_name, value)
-							
+
 								value.parent = self if value
 							else
 								raise TypeMismatch.new(type, value.class)
 							end
 						end
-						
+
 					else
 						define_method((name.to_s + '=').to_sym) do |value|
 							if value.is_a?(type) or value == nil
 								self.instance_variable_set(ivar_name, value)
-								
+
 							else
 								raise TypeMismatch.new(type, value.class)
 							end
 						end
 					end
-					
+
 				else
 					type = type.first
-					
+
 					if set_parent
 						define_method((name.to_s + '=').to_sym) do |value|
 							if value.inject(true) { |m, o| m and o.is_a?(type) }
 								self.instance_variable_set(ivar_name, value)
-							
+
 								value.each { |c| c.parent = self }
 							else
 								raise TypeMismatch.new(type, value.class)
 							end
 						end
-						
+
 					else
 						define_method((name.to_s + '=').to_sym) do |value|
 							if value.inject(true) { |m, o| m and o.is_a?(type) }
 								self.instance_variable_set(ivar_name, value)
-								
+
 							else
 								raise TypeMismatch.new(type, value.class)
 							end
@@ -172,7 +172,7 @@ module RLTK # :nodoc:
 				end
 			end
 			private :define_accessor
-			
+
 			# Defined a value for this AST class and its subclasses.
 			# The name of the value will be used to define accessor
 			# methods that include type checking.  The type of this
@@ -185,34 +185,34 @@ module RLTK # :nodoc:
 			def value(name, type)
 				if type.is_a?(Array) and type.length == 1
 					t = type.first
-				
+
 				elsif type.is_a?(Class)
 					t = type
-					
+
 				else
 					raise 'Child and Value types must be a class name or an array with a single class name element.'
 				end
-				
+
 				# Check to make sure that type is NOT a subclass of
 				# ASTNode.
 				if t.subclass_of?(ASTNode)
 					raise "A value's type specification must NOT be a subclass of ASTNode."
 				end
-				
+
 				@value_names << name
 				define_accessor(name, type)
 			end
-			
+
 			# @return [Array<Symbol>] Array of the names of this node class's values.
 			def value_names
 				@value_names
 			end
 		end
-		
+
 		####################
 		# Instance Methods #
 		####################
-		
+
 		# Used for AST comparison, this function will return true if the two
 		# nodes are of the same class and all of their values and children
 		# are equal.
@@ -223,32 +223,32 @@ module RLTK # :nodoc:
 		def ==(other)
 			self.class == other.class and self.values == other.values and self.children == other.children
 		end
-		
+
 		# @return [Object] Note with the name *key*.
 		def [](key)
 			@notes[key]
 		end
-		
+
 		# Sets the note named *key* to *value*.
 		def []=(key, value)
 			@notes[key] = value
 		end
-		
+
 		# @param [Class] as The type that should be returned by the method.  Must be either Array or hash.
 		#
 		# @return [Array<ASTNode>, Hash{Symbol => ASTNode}] Array or Hash of this node's children.
 		def children(as = Array)
 			if as == Array
 				self.class.child_names.map { |name| self.send(name) }
-			
+
 			elsif as == Hash
 				self.class.child_names.inject(Hash.new) { |h, name| h[name] = self.send(name); h }
-			
+
 			else
 				raise 'Children can only be returned as an Array or a Hash.'
 			end
 		end
-		
+
 		# Assigns an array or hash of AST nodes as the children of this node.
 		# If a hash is provided as an argument the key is used as the name of
 		# the child a object should be assigned to.
@@ -262,11 +262,11 @@ module RLTK # :nodoc:
 				if children.length != self.class.child_names.length
 					raise 'Wrong number of children specified.'
 				end
-			
+
 				self.class.child_names.each_with_index do |name, i|
 					self.send((name.to_s + '=').to_sym, children[i])
 				end
-				
+
 			when Hash
 				children.each do |name, val|
 					if self.class.child_names.include?(name)
@@ -277,14 +277,14 @@ module RLTK # :nodoc:
 				end
 			end
 		end
-		
+
 		# Produce an exact copy of this tree.
 		#
 		# @return [ASTNode] A copy of the tree.
 		def copy
 			self.map { |c| c }
 		end
-		
+
 		# Removes the note *key* from this node.  If the *recursive* argument
 		# is true it will also remove the note from the node's children.
 		#
@@ -294,7 +294,7 @@ module RLTK # :nodoc:
 			if recursive
 				self.children.each do |child|
 					next if not child
-					
+
 					if child.is_a?(Array)
 						child.each { |c| c.delete_note(key, true) }
 					else
@@ -302,10 +302,10 @@ module RLTK # :nodoc:
 					end
 				end
 			end
-			
+
 			@notes.delete(key)
 		end
-		
+
 		# This method is a simple wrapper around Marshal.dump, and is used
 		# to serialize an AST.  You can use Marshal.load to reconstruct a
 		# serialized AST.
@@ -322,7 +322,7 @@ module RLTK # :nodoc:
 			else	raise TypeError, "AST#dump expects nil, a String, or an IO object for the dest parameter."
 			end
 		end
-		
+
 		# An iterator over the node's children.  The AST may be traversed in
 		# the following orders:
 		#
@@ -337,31 +337,31 @@ module RLTK # :nodoc:
 			case order
 			when :pre
 				yield self
-				
+
 				self.children.flatten.compact.each { |c| c.each(:pre, &block) }
-				
+
 			when :post
 				self.children.flatten.compact.each { |c| c.each(:post, &block) }
-				
+
 				yield self
-				
+
 			when :level
 				level_queue = [self]
-				
+
 				while node = level_queue.shift
 					yield node
-					
+
 					level_queue += node.children.flatten.compact
 				end
 			end
 		end
-		
+
 		# Tests to see if a note named *key* is present at this node.
 		def has_note?(key)
 			@notes.has_key?(key)
 		end
 		alias :'note?' :'has_note?'
-		
+
 		# Instantiates a new ASTNode object.  The arguments to this method are
 		# split into two lists: the set of values for this node and a list of
 		# its children.  If the node has 2 values and 3 children you would
@@ -379,18 +379,18 @@ module RLTK # :nodoc:
 			else
 				@notes	= Hash.new()
 				@parent	= nil
-				
+
 				# Pad out the objects array with nil values.
 				max_args = self.class.value_names.length + self.class.child_names.length
 				objects.fill(nil, objects.length...max_args)
-				
+
 				pivot = self.class.value_names.length
-				
+
 				self.values	= objects[0...pivot]
 				self.children	= objects[pivot..-1]
 			end
 		end
-		
+
 		# Create a new tree by using the provided Proc object to map the
 		# nodes of this tree to new nodes.  This is always done in
 		# post-order, meaning that all children of a node are visited before
@@ -401,7 +401,7 @@ module RLTK # :nodoc:
 		# @return [Object] The result of calling the given block on the root node.
 		def map(&block)
 			new_values = self.values.map { |v| v.clone }
-			
+
 			new_children =
 			self.children.map do |c0|
 				case c0
@@ -410,13 +410,13 @@ module RLTK # :nodoc:
 				when NilClass	then nil
 				end
 			end
-			
-			new_node		= self.class.new(*new_values, *new_children)
+
+			new_node		= self.class.new(*new_values + new_children)
 			new_node.notes = self.notes
-			
+
 			block.call(new_node)
 		end
-		
+
 		# Map the nodes in an AST to new nodes using the provided Proc
 		# object.  This is always done in post-order, meaning that all
 		# children of a node are visited before the node itself.
@@ -435,10 +435,10 @@ module RLTK # :nodoc:
 				when NilClass	then nil
 				end
 			end
-			
+
 			block.call(self)
 		end
-		
+
 		# Set the notes for this node from a given hash.
 		#
 		# @param [Hash] new_notes The new notes for this node.
@@ -447,27 +447,27 @@ module RLTK # :nodoc:
 		def notes=(new_notes)
 			@notes = new_notes.clone
 		end
-		
+
 		# @return [ASTNode] Root of the abstract syntax tree.
 		def root
 			if @parent then @parent.root else self end
 		end
-		
+
 		# @param [Class] as The type that should be returned by the method.  Must be either Array or hash.
 		#
 		# @return [Array<Object>, Hash{Symbol => Object}] Array or Hash of this node's values.
 		def values(as = Array)
 			if as == Array
 				self.class.value_names.map { |name| self.send(name) }
-			
+
 			elsif as == Hash
 				self.class.value_names.inject(Hash.new) { |h, name| h[name] = self.send(name); h }
-			
+
 			else
 				raise 'Values can only be returned as an Array or a Hash.'
 			end
 		end
-		
+
 		# Assigns an array or hash of objects as the values of this node.  If
 		# a hash is provided as an argument the key is used as the name of
 		# the value an object should be assigned to.
@@ -479,11 +479,11 @@ module RLTK # :nodoc:
 				if values.length != self.class.value_names.length
 					raise 'Wrong number of values specified.'
 				end
-			
+
 				self.class.value_names.each_with_index do |name, i|
 					self.send((name.to_s + '=').to_sym, values[i])
 				end
-				
+
 			when Hash
 				values.each do |name, val|
 					if self.class.value_names.include?(name)

--- a/lib/rltk/visitor.rb
+++ b/lib/rltk/visitor.rb
@@ -8,42 +8,42 @@
 #######################
 
 module RLTK # :nodoc:
-	
+
 	# An implementation of the visitor pattern.
 	#
 	# @see http://en.wikipedia.org/wiki/Visitor_pattern
 	module Visitor
-		
+
 		#################
 		# Class Methods #
 		#################
-		
+
 		# A callback method that installs the necessary data structures and
 		# class methods in classes that include the Visitor module.
 		#
 		# @return [void]
 		def self.included(klass)
 			klass.extend(ClassMethods)
-			
+
 			klass.install_icvars(Array.new)
 		end
-		
+
 		module ClassMethods
 			# @return [Array<Action>] Actions associated with this visitor.
 			attr_reader :actions
-			
-			
+
+
 			def inherited(klass)
 				klass.install_icvars(@actions.clone)
 			end
-			
+
 			# Installs instance class varialbes into a class.
 			#
 			# @return [void]
 			def install_icvars(inherited_actions)
 				@actions = inherited_actions
 			end
-			
+
 			# The main method used to construct visitor classes.  When the
 			# {#visit} method is called on an object the visitor will serach
 			# through the list of actions defined using the {.on} method and
@@ -63,7 +63,7 @@ module RLTK # :nodoc:
 			#     yield(o)
 			#     common_teardown
 			#   end
-			#   
+			#
 			#   on Foo, wrapper: my_wrapper { |o| specific_stuff }
 			#
 			# @param [Class]	klass	The class that this action applies to.
@@ -76,15 +76,15 @@ module RLTK # :nodoc:
 			# @return [void]
 			def on(klass, opts = {}, &block)
 				raise ArgumentError, 'The klass parameter was not a Class.' if not klass.is_a?(Class)
-				
+
 				@actions << Action.new(klass, opts[:guard], opts[:wrapper], block)
 			end
 		end
-		
+
 		####################
 		# Instance Methods #
 		####################
-		
+
 		# Visit an object.
 		#
 		# The list of actions are first filtered using the class given as the
@@ -94,7 +94,7 @@ module RLTK # :nodoc:
 		#
 		# Once all possible candidates are selected using this method the
 		# visitor will select the best one using the following criteria:
-		# 
+		#
 		# * More specific actions are preferred.  An action defined for
 		#   Integer will be selected over an action for Numeric when visiting
 		#   an integer.
@@ -110,9 +110,9 @@ module RLTK # :nodoc:
 		def visit(object)
 			# Find candidate matches.
 			candidates = self.class.actions.select { |a| object.is_a?(a.klass) and (if a.guard then a.guard[object] else true end) }
-			
+
 			raise 'No actions defined for given object.' if candidates.empty?
-			
+
 			# Find the best candidate match.
 			action =
 			candidates.inject(candidates.pop) do |best, cur|
@@ -123,33 +123,33 @@ module RLTK # :nodoc:
 				#
 				# If two matches are equally good go with the first one
 				# defined.
-				
+
 				better   = cur.klass.subclass_of?(best.klass)
 				better ||= best.klass == cur.klass and best.guard.nil? and not cur.guard.nil?
-		
+
 				if better then cur else best end
 			end
-			
+
 			# Visit the object.
 			if action.wrapper
 				# Create the instance exec cache if it doesn't exist.
 				@iexec_cache ||= Hash.new
-				
+
 				# Create the instance exec callback if it isn't already cached.
-				@iexec_cache[action] ||= ->(*args) { self.instance_exec(*args, &action.block) }
-				
+				@iexec_cache[action] ||= proc { |*args| self.instance_exec(*args, &action.block) }
+
 				# Call the wrapper with the object and the instance exec wrapped block.
 				self.send(action.wrapper, object, &@iexec_cache[action])
-				
+
 			else
 				self.instance_exec(object, &action.block)
 			end
 		end
-		
+
 		#################
 		# Inner Classes #
 		#################
-		
+
 		# A POD used to hold data about an action.
 		Action = Struct.new(:klass, :guard, :wrapper, :block)
 	end

--- a/test/tc_ast.rb
+++ b/test/tc_ast.rb
@@ -28,66 +28,52 @@ class ASTNodeTester < Test::Unit::TestCase
 	class CNode < ANode; end
 
 	class DNode < RLTK::ASTNode; end
-	
+
 	class ENode < RLTK::ASTNode
 		value :str, String
 	end
-	
+
 	class FNode < ENode
 		child :c, [ENode]
 	end
-	
+
 	class SNode < RLTK::ASTNode
 		value :string, String
-		
+
 		child :left, SNode
 		child :right, SNode
 	end
-	
+
 	class VNode < RLTK::ASTNode
 		value :a, Integer
 		value :b, Integer
 	end
-	
+
 	def setup
 		@leaf0 = CNode.new
 		@tree0 = ANode.new(BNode.new(@leaf0), BNode.new)
-		
+
 		@tree1 = ANode.new(BNode.new(CNode.new), BNode.new)
 		@tree2 = ANode.new(BNode.new, BNode.new(CNode.new))
 		@tree3 = ANode.new(CNode.new(BNode.new), CNode.new)
-		
-		@tree4 =	SNode.new('F',
-					SNode.new('B',
-						SNode.new('A'),
-						SNode.new('D',
-							SNode.new('C'),
-							SNode.new('E')
-						),
-					),
-					SNode.new('G',
-						nil,
-						SNode.new('I',
-							SNode.new('H')
-						)
-					)
-				)
-		
+
+                @tree4 = SNode.new('F', SNode.new('B', SNode.new('A'), SNode.new('D', SNode.new('C'), SNode.new('E'))), SNode.new('G', nil, SNode.new('I', SNode.new('H'))))
+
 		@tree5 = FNode.new('one',
 				[FNode.new('two',
 					[ENode.new('three')]),
 				ENode.new('four')])
-		
+
 		@tree6 = FNode.new('one',
 				[FNode.new('two',
 					[ENode.new('three')]),
 				ENode.new('four')])
-		
+
 		@tree7 = FNode.new('one!',
 				[FNode.new('two!',
 					[ENode.new('three!')]),
 				ENode.new('four!')])
-		
+
 		@bc_proc = Proc.new do |n|
 			case n
 			when BNode then	CNode.new(n.left, n.right)
@@ -96,137 +82,137 @@ class ASTNodeTester < Test::Unit::TestCase
 			end
 		end
 	end
-	
+
 	def test_children
 		node = ANode.new
-		
+
 		assert_equal(node.children, [nil, nil])
-		
+
 		node.children = (expected_children = [BNode.new, CNode.new])
-		
+
 		assert_equal(node.children, expected_children)
-		
+
 		node.children = (expected_children = {:left => CNode.new, :right => BNode.new})
-		
+
 		assert_equal(node.children(Hash), expected_children)
 	end
-	
+
 	def test_copy
 		new_tree = @tree5.copy
-		
+
 		assert_equal(@tree5, new_tree)
 	end
-	
+
 	def test_value
 		node = VNode.new
-		
+
 		assert_equal(node.values, [nil, nil])
-		
+
 		node.values = (expected_values = [42, 1984])
-		
+
 		assert_equal(node.values, expected_values)
-		
+
 		node.values = (expected_values = {:a => 1984, :b => 42})
-		
+
 		assert_equal(node.values(Hash), expected_values)
 	end
-	
+
 	def test_dump
 		tree0_string = @tree0.dump
-		
+
 		reloaded_tree = Marshal.load(tree0_string)
-		
+
 		assert_equal(@tree0, reloaded_tree)
 	end
-	
+
 	def test_each
 		# Test pre-order
 		nodes	= []
 		expected	= ['F', 'B', 'A', 'D', 'C', 'E', 'G', 'I', 'H']
 		@tree4.each(:pre) { |n| nodes << n.string }
-		
+
 		assert_equal(expected, nodes)
-		
+
 		# Test post-order
 		nodes	= []
 		expected	= ['A', 'C', 'E', 'D', 'B', 'H', 'I', 'G', 'F']
 		@tree4.each(:post) { |n| nodes << n.string }
-		
+
 		assert_equal(expected, nodes)
-		
+
 		# Test level-order
 		nodes	= []
 		expected	= ['F', 'B', 'G', 'A', 'D', 'I', 'C', 'E', 'H']
 		@tree4.each(:level) { |n| nodes << n.string }
-		
+
 		assert_equal(expected, nodes)
-		
+
 		# Test iteration with array children.
-		
+
 		res	= ''
 		@tree5.each(:pre) { |node| res += ' ' + node.str }
 		assert_equal(res, ' one two three four')
-		
+
 		res	= ''
 		@tree5.each(:post) { |node| res += ' ' + node.str }
 		assert_equal(res, ' three two four one')
-		
+
 		res	= ''
 		@tree5.each(:level) { |node| res += ' ' + node.str }
 		assert_equal(res, ' one two four three')
 	end
-	
+
 	def test_equal
 		assert_equal(@tree0, @tree1)
 		assert_not_equal(@tree0, @tree2)
 	end
-	
+
 	def test_initialize
 		assert_raise(RuntimeError) { RLTK::ASTNode.new }
 		assert_nothing_raised(RuntimeError) { ANode.new }
 	end
-	
+
 	def test_map
 		mapped_tree = @tree1.map(&@bc_proc)
-		
+
 		assert_equal(@tree0, @tree1)
 		assert_equal(@tree3, mapped_tree)
-		
+
 		mapped_tree = @tree5.map do |c|
 			c.str += '!'
-			
+
 			c
 		end
-		
+
 		assert_equal(@tree6, @tree5)
 		assert_equal(@tree7, mapped_tree)
 	end
-	
+
 	def test_map!
 		tree1_clone = @tree1.clone
 		tree1_clone.map!(&@bc_proc)
-		
+
 		assert_not_equal(@tree1, tree1_clone)
 		assert_equal(@tree3, tree1_clone)
-		
+
 		replace_node = BNode.new
 		replace_node = replace_node.map!(&@bc_proc)
-		
+
 		assert_equal(CNode.new, replace_node)
-		
+
 		mapped_tree = @tree5.map! do |c|
 			c.str += '!'
-			
+
 			c
 		end
-		
+
 		assert_not_equal(@tree6, @tree5)
 		assert_equal(@tree7, @tree5)
 	end
-	
+
 	def test_notes
 		node = ANode.new
-		
+
 		assert_nil(node[:a])
 		assert_equal(node[:a] = :b, :b)
 		assert_equal(node.note?(:a), true)
@@ -234,7 +220,7 @@ class ASTNodeTester < Test::Unit::TestCase
 		assert_equal(node.delete_note(:a), :b)
 		assert_nil(node[:a])
 	end
-	
+
 	def test_root
 		assert_same(@tree0, @tree0.root)
 		assert_same(@tree0, @leaf0.root)

--- a/test/tc_parser.rb
+++ b/test/tc_parser.rb
@@ -27,509 +27,509 @@ class ParserTester < Test::Unit::TestCase
 	class ABLexer < RLTK::Lexer
 		rule(/a/) { [:A, 1] }
 		rule(/b/) { [:B, 2] }
-		
+
 		rule(/\s/)
 	end
-	
+
 	class AlphaLexer < RLTK::Lexer
 		rule(/[A-Za-z]/) { |t| [t.upcase.to_sym, t] }
-		
+
 		rule(/,/) { :COMMA }
-		
+
 		rule(/\s/)
 	end
-	
+
 	class UnderscoreLexer < RLTK::Lexer
 		rule(/\w/) { |t| [:A_TOKEN, t] }
 	end
-	
+
 	class APlusBParser < RLTK::Parser
 		production(:a, 'A+ B') { |a, _| a.length }
-		
+
 		finalize
 	end
-	
+
 	class AQuestionBParser < RLTK::Parser
 		production(:a, 'A? B') { |a, _| a }
-		
+
 		finalize
 	end
-	
+
 	class AStarBParser < RLTK::Parser
 		production(:a, 'A* B') { |a, _| a.length }
-		
+
 		finalize
 	end
-	
+
 	class AmbiguousParser < RLTK::Parser
 		production(:e) do
 			clause('NUM') {|n| n}
-			
+
 			clause('e PLS e') { |e0, _, e1| e0 + e1 }
 			clause('e SUB e') { |e0, _, e1| e0 - e1 }
 			clause('e MUL e') { |e0, _, e1| e0 * e1 }
 			clause('e DIV e') { |e0, _, e1| e0 / e1 }
 		end
-		
+
 		finalize
 	end
-	
+
 	class ArrayCalc < RLTK::Parser
 		dat :array
-		
+
 		production(:e) do
 			clause('NUM') { |v| v[0] }
-		
+
 			clause('PLS e e') { |v| v[1] + v[2] }
 			clause('SUB e e') { |v| v[1] - v[2] }
 			clause('MUL e e') { |v| v[1] * v[2] }
 			clause('DIV e e') { |v| v[1] / v[2] }
 		end
-		
+
 		finalize
 	end
-	
+
 	# This grammar is purposefully ambiguous.  This should not be equivalent
 	# to the grammar produced with `e -> A B? B?`, due to greedy Kleene
 	# operators.
 	class AmbiguousParseStackParser < RLTK::Parser
 		production(:s, 'e*') { |e| e }
-		
+
 		production(:e, 'A b_question b_question') { |a, b0, b1| [a, b0, b1] }
-		
+
 		production(:b_question) do
 			clause('')	{ | | nil }
 			clause('B')	{ |b|   b }
 		end
-		
+
 		finalize
 	end
-	
+
 	class EmptyListParser0 < RLTK::Parser
 		empty_list('list', :A, :COMMA)
-		
+
 		finalize
 	end
-	
+
 	class EmptyListParser1 < RLTK::Parser
 		dat :array
-		
+
 		empty_list('list', ['A', 'B', 'C D'], :COMMA)
-		
+
 		finalize
 	end
-	
+
 	class NonEmptyListParser0 < RLTK::Parser
 		nonempty_list('list', :A, :COMMA)
-		
+
 		finalize
 	end
-	
+
 	class NonEmptyListParser1 < RLTK::Parser
 		nonempty_list('list', [:A, :B], :COMMA)
-		
+
 		finalize
 	end
-	
+
 	class NonEmptyListParser2 < RLTK::Parser
 		nonempty_list('list', ['A', 'B', 'C D'], :COMMA)
-		
+
 		finalize
 	end
-	
+
 	class NonEmptyListParser3 < RLTK::Parser
 		nonempty_list('list', 'A+', :COMMA)
-		
+
 		finalize
 	end
-	
+
 	class NonEmptyListParser4 < RLTK::Parser
 		nonempty_list('list', :A)
-		
+
 		finalize
 	end
-	
+
 	class NonEmptyListParser5 < RLTK::Parser
 		nonempty_list('list', :A, 'B C?')
-		
+
 		finalize
 	end
-	
+
 	class DummyError1 < StandardError; end
 	class DummyError2 < StandardError; end
-	
+
 	class ErrorCalc < RLTK::Parser
 		left :ERROR
 		right :PLS, :SUB, :MUL, :DIV, :NUM
-		
+
 		production(:e) do
 			clause('NUM') {|n| n}
-		
+
 			clause('e PLS e') { |e0, _, e1| e0 + e1 }
 			clause('e SUB e') { |e0, _, e1| e0 - e1 }
 			clause('e MUL e') { |e0, _, e1| e0 * e1 }
 			clause('e DIV e') { |e0, _, e1| e0 / e1 }
-		
+
 			clause('e PLS ERROR e') { |e0, _, ts, e1| error(ts); e0 + e1 }
 		end
-	
+
 		finalize
 	end
 
 	class ELLexer < RLTK::Lexer
 		rule(/\n/)	{ :NEWLINE }
 		rule(/;/)		{ :SEMI    }
-	
+
 		rule(/\s/)
-	
+
 		rule(/[A-Za-z]+/)	{ |t| [:WORD, t] }
 	end
 
 	class ErrorLine < RLTK::Parser
-	
+
 		production(:s, 'line*') { |l| l }
-	
+
 		production(:line) do
 			clause('NEWLINE') { |_| nil }
-		
+
 			clause('WORD+ SEMI NEWLINE')	{ |w, _, _| w }
 			clause('WORD+ ERROR')		{ |w, e| error(pos(1).line_number); w }
 		end
-	
+
 		finalize
 	end
-	
+
 	class UnderscoreParser < RLTK::Parser
 		production(:s, 'A_TOKEN+') { |o| o }
-		
+
 		finalize
 	end
-	
+
 	class RotatingCalc < RLTK::Parser
 		production(:e) do
 			clause('NUM') {|n| n}
-		
+
 			clause('PLS e e') { |_, e0, e1| e0.send(get_op(:+), e1) }
 			clause('SUB e e') { |_, e0, e1| e0.send(get_op(:-), e1) }
 			clause('MUL e e') { |_, e0, e1| e0.send(get_op(:*), e1) }
 			clause('DIV e e') { |_, e0, e1| e0.send(get_op(:/), e1) }
 		end
-	
+
 		class Environment < Environment
 			def initialize
 				@map = { :+ => 0, :- => 1, :* => 2, :/ => 3 }
 				@ops = [ :+, :-, :*, :/ ]
 			end
-		
+
 			def get_op(orig_op)
 				new_op = @ops[@map[orig_op]]
-			
+
 				@ops = @ops[1..-1] << @ops[0]
-			
+
 				new_op
 			end
 		end
-	
+
 		finalize
 	end
-	
+
 	def test_ambiguous_grammar
 		actual = AmbiguousParser.parse(RLTK::Lexers::Calculator.lex('1 + 2 * 3'), {:accept => :all})
 		assert_equal([7, 9], actual.sort)
 	end
-	
+
 	# This test is to ensure that objects placed on the output stack are
 	# cloned when we split the parse stack.  This was posted as Issue #17 on
 	# Github.
 	def test_ambiguous_parse_stack
 		assert_equal(1, AmbiguousParseStackParser.parse(ABLexer.lex('ab')).length)
 	end
-	
+
 	def test_array_args
 		actual = ArrayCalc.parse(RLTK::Lexers::Calculator.lex('+ 1 2'))
 		assert_equal(3, actual)
-		
+
 		actual = ArrayCalc.parse(RLTK::Lexers::Calculator.lex('+ 1 * 2 3'))
 		assert_equal(7, actual)
-		
+
 		actual = ArrayCalc.parse(RLTK::Lexers::Calculator.lex('* + 1 2 3'))
 		assert_equal(9, actual)
 	end
-	
+
 	def test_ebnf_parsing
 		################
 		# APlusBParser #
 		################
-		
+
 		assert_raise(RLTK::NotInLanguage) { APlusBParser.parse(ABLexer.lex('b')) }
 		assert_equal(1, APlusBParser.parse(ABLexer.lex('ab')))
 		assert_equal(2, APlusBParser.parse(ABLexer.lex('aab')))
 		assert_equal(3, APlusBParser.parse(ABLexer.lex('aaab')))
 		assert_equal(4, APlusBParser.parse(ABLexer.lex('aaaab')))
-		
+
 		####################
 		# AQuestionBParser #
 		####################
-		
+
 		assert_raise(RLTK::NotInLanguage) { AQuestionBParser.parse(ABLexer.lex('aab')) }
 		assert_nil(AQuestionBParser.parse(ABLexer.lex('b')))
 		assert_not_nil(AQuestionBParser.parse(ABLexer.lex('ab')))
-		
+
 		################
 		# AStarBParser #
 		################
-		
+
 		assert_equal(0, AStarBParser.parse(ABLexer.lex('b')))
 		assert_equal(1, AStarBParser.parse(ABLexer.lex('ab')))
 		assert_equal(2, AStarBParser.parse(ABLexer.lex('aab')))
 		assert_equal(3, AStarBParser.parse(ABLexer.lex('aaab')))
 		assert_equal(4, AStarBParser.parse(ABLexer.lex('aaaab')))
 	end
-	
+
 	def test_empty_list
 		####################
 		# EmptyListParser0 #
 		####################
-		
+
 		expected	= []
 		actual	= EmptyListParser0.parse(AlphaLexer.lex(''))
 		assert_equal(expected, actual)
-		
+
 		####################
 		# EmptyListParser1 #
 		####################
-		
+
 		expected	= ['a', 'b', ['c', 'd']]
 		actual	= EmptyListParser1.parse(AlphaLexer.lex('a, b, c d'))
 		assert_equal(expected, actual)
 	end
-	
+
 	def test_environment
 		actual = RotatingCalc.parse(RLTK::Lexers::Calculator.lex('+ 1 2'))
 		assert_equal(3, actual)
-		
+
 		actual = RotatingCalc.parse(RLTK::Lexers::Calculator.lex('/ 1 * 2 3'))
 		assert_equal(7, actual)
-		
+
 		actual = RotatingCalc.parse(RLTK::Lexers::Calculator.lex('- + 1 2 3'))
 		assert_equal(9, actual)
-		
+
 		parser = RotatingCalc.new
-		
+
 		actual = parser.parse(RLTK::Lexers::Calculator.lex('+ 1 2'))
 		assert_equal(3, actual)
-		
+
 		actual = parser.parse(RLTK::Lexers::Calculator.lex('/ 1 2'))
 		assert_equal(3, actual)
 	end
-	
+
 	def test_error_productions
-		
+
 		# Test to see if error reporting is working correctly.
-		
+
 		test_string  = "first line;\n"
 		test_string += "second line\n"
 		test_string += "third line;\n"
 		test_string += "fourth line\n"
-		
+
 		assert_raise(RLTK::HandledError) { ErrorLine.parse(ELLexer.lex(test_string)) }
-		
+
 		begin
 			ErrorLine.parse(ELLexer.lex(test_string))
-			
+
 		rescue RLTK::HandledError => e
 			assert_equal([2,4], e.errors)
 		end
-		
+
 		# Test to see if we can continue parsing after errors are encounterd.
-		
+
 		begin
 			ErrorCalc.parse(RLTK::Lexers::Calculator.lex('1 + + 1'))
-			
+
 		rescue RLTK::HandledError => e
 			assert_equal(1, e.errors.first.length)
 			assert_equal(2, e.result)
 		end
-		
+
 		# Test to see if we pop tokens correctly after an error is
 		# encountered.
-		
+
 		begin
 			ErrorCalc.parse(RLTK::Lexers::Calculator.lex('1 + + + + + + 1'))
-			
+
 		rescue RLTK::HandledError => e
 			assert_equal(5, e.errors.first.length)
 			assert_equal(2, e.result)
 		end
 	end
-	
+
 	def test_infix_calc
 		actual = RLTK::Parsers::InfixCalc.parse(RLTK::Lexers::Calculator.lex('1 + 2'))
 		assert_equal(3, actual)
-		
+
 		actual = RLTK::Parsers::InfixCalc.parse(RLTK::Lexers::Calculator.lex('1 + 2 * 3'))
 		assert_equal(7, actual)
-		
+
 		actual = RLTK::Parsers::InfixCalc.parse(RLTK::Lexers::Calculator.lex('(1 + 2) * 3'))
 		assert_equal(9, actual)
-		
+
 		assert_raise(RLTK::NotInLanguage) { RLTK::Parsers::InfixCalc.parse(RLTK::Lexers::Calculator.lex('1 2 + 3 *')) }
 	end
-	
+
 	def test_input
 		assert_raise(RLTK::BadToken) { RLTK::Parsers::InfixCalc.parse(RLTK::Lexers::EBNF.lex('A B C')) }
 	end
-	
+
 	def test_nonempty_list
 		#######################
 		# NonEmptyListParser0 #
 		#######################
-		
+
 		expected	= ['a']
 		actual	= NonEmptyListParser0.parse(AlphaLexer.lex('a'))
 		assert_equal(expected, actual)
-		
+
 		expected	= ['a', 'a']
 		actual	= NonEmptyListParser0.parse(AlphaLexer.lex('a, a'))
 		assert_equal(expected, actual)
-		
+
 		assert_raise(RLTK::NotInLanguage) { NonEmptyListParser0.parse(AlphaLexer.lex(''))   }
 		assert_raise(RLTK::NotInLanguage) { NonEmptyListParser0.parse(AlphaLexer.lex(','))  }
 		assert_raise(RLTK::NotInLanguage) { NonEmptyListParser0.parse(AlphaLexer.lex('aa')) }
 		assert_raise(RLTK::NotInLanguage) { NonEmptyListParser0.parse(AlphaLexer.lex('a,')) }
 		assert_raise(RLTK::NotInLanguage) { NonEmptyListParser0.parse(AlphaLexer.lex(',a')) }
-		
+
 		#######################
 		# NonEmptyListParser1 #
 		#######################
-		
+
 		expected	= ['a']
 		actual	= NonEmptyListParser1.parse(AlphaLexer.lex('a'))
 		assert_equal(expected, actual)
-		
+
 		expected	= ['b']
 		actual	= NonEmptyListParser1.parse(AlphaLexer.lex('b'))
 		assert_equal(expected, actual)
-		
+
 		expected	= ['a', 'b', 'a', 'b']
 		actual	= NonEmptyListParser1.parse(AlphaLexer.lex('a, b, a, b'))
 		assert_equal(expected, actual)
-		
+
 		assert_raise(RLTK::NotInLanguage) { NonEmptyListParser1.parse(AlphaLexer.lex('a b')) }
 		assert_raise(RLTK::NotInLanguage) { NonEmptyListParser1.parse(AlphaLexer.lex('a, ')) }
-		
+
 		#######################
 		# NonEmptyListParser2 #
 		#######################
-		
+
 		expected	= ['a']
 		actual	= NonEmptyListParser2.parse(AlphaLexer.lex('a'))
 		assert_equal(expected, actual)
-		
+
 		expected	= ['b']
 		actual	= NonEmptyListParser2.parse(AlphaLexer.lex('b'))
 		assert_equal(expected, actual)
-		
+
 		expected	= [['c', 'd']]
 		actual	= NonEmptyListParser2.parse(AlphaLexer.lex('c d'))
 		assert_equal(expected, actual)
-		
+
 		expected	= [['c', 'd'], ['c', 'd']]
 		actual	= NonEmptyListParser2.parse(AlphaLexer.lex('c d, c d'))
 		assert_equal(expected, actual)
-		
+
 		expected	= ['a', 'b', ['c', 'd']]
 		actual	= NonEmptyListParser2.parse(AlphaLexer.lex('a, b, c d'))
 		assert_equal(expected, actual)
-		
+
 		assert_raise(RLTK::NotInLanguage) { NonEmptyListParser2.parse(AlphaLexer.lex('c')) }
 		assert_raise(RLTK::NotInLanguage) { NonEmptyListParser2.parse(AlphaLexer.lex('d')) }
-		
+
 		#######################
 		# NonEmptyListParser3 #
 		#######################
-		
+
 		expected	= [['a'], ['a', 'a'], ['a', 'a', 'a']]
 		actual	= NonEmptyListParser3.parse(AlphaLexer.lex('a, aa, aaa'))
 		assert_equal(expected, actual)
-		
+
 		#######################
 		# NonEmptyListParser4 #
 		#######################
-		
+
 		expected	= ['a', 'a', 'a']
 		actual	= NonEmptyListParser4.parse(AlphaLexer.lex('a a a'))
 		assert_equal(expected, actual)
-		
+
 		#######################
 		# NonEmptyListParser5 #
 		#######################
-		
+
 		expected	= ['a', 'a', 'a']
 		actual	= NonEmptyListParser5.parse(AlphaLexer.lex('a b a b c a'))
 		assert_equal(expected, actual)
-		
+
 		assert_raise(RLTK::NotInLanguage) { NonEmptyListParser5.parse(AlphaLexer.lex('a b b a')) }
 	end
-	
+
 	def test_postfix_calc
 		actual = RLTK::Parsers::PostfixCalc.parse(RLTK::Lexers::Calculator.lex('1 2 +'))
 		assert_equal(3, actual)
-		
+
 		actual = RLTK::Parsers::PostfixCalc.parse(RLTK::Lexers::Calculator.lex('1 2 3 * +'))
 		assert_equal(7, actual)
-		
+
 		actual = RLTK::Parsers::PostfixCalc.parse(RLTK::Lexers::Calculator.lex('1 2 + 3 *'))
 		assert_equal(9, actual)
-		
+
 		assert_raise(RLTK::NotInLanguage) { RLTK::Parsers::InfixCalc.parse(RLTK::Lexers::Calculator.lex('* + 1 2 3')) }
 	end
-	
+
 	def test_prefix_calc
 		actual = RLTK::Parsers::PrefixCalc.parse(RLTK::Lexers::Calculator.lex('+ 1 2'))
 		assert_equal(3, actual)
-		
+
 		actual = RLTK::Parsers::PrefixCalc.parse(RLTK::Lexers::Calculator.lex('+ 1 * 2 3'))
 		assert_equal(7, actual)
-		
+
 		actual = RLTK::Parsers::PrefixCalc.parse(RLTK::Lexers::Calculator.lex('* + 1 2 3'))
 		assert_equal(9, actual)
-		
+
 		assert_raise(RLTK::NotInLanguage) { RLTK::Parsers::PrefixCalc.parse(RLTK::Lexers::Calculator.lex('1 + 2 * 3')) }
 	end
-	
+
 	def test_underscore_tokens
 		actual	= UnderscoreParser.parse(UnderscoreLexer.lex('abc')).join
 		expected	= 'abc'
-		
+
 		assert_equal(expected, actual)
 	end
-	
+
 	def test_use
 		tmpfile = File.join(Dir.tmpdir, 'usetest')
-		
+
 		FileUtils.rm(tmpfile) if File.exist?(tmpfile)
-		
+
 		parser0 = Class.new(RLTK::Parser) do
 			production(:a, 'A+') { |a| a.length }
-			
-			finalize use: tmpfile
+
+			finalize :use => tmpfile
 		end
-		
+
 		result0 = parser0.parse(ABLexer.lex('a'))
-		
+
 		assert(File.exist?(tmpfile), 'Serialized parser file not found.')
-		
+
 		parser1 = Class.new(RLTK::Parser) do
 			production(:a, 'A+') { |a| a.length }
-			
-			finalize use: tmpfile
+
+			finalize :use => tmpfile
 		end
-		
+
 		result1 = parser1.parse(ABLexer.lex('a'))
-		
+
 		assert_equal(result0, result1)
-		
+
 		File.unlink(tmpfile)
-	end
+	end unless RUBY_VERSION =~ /^1\.8*/
 end

--- a/test/tc_visitor.rb
+++ b/test/tc_visitor.rb
@@ -20,40 +20,40 @@ require 'rltk/visitor'
 class VisitorTester < Test::Unit::TestCase
 	class GuardedVisitor
 		include RLTK::Visitor
-		
-		on Integer, guard: ->(i) { i < 10 } do
+
+		on Integer, :guard => proc { |i| i < 10 } do
 			true
 		end
-		
+
 		on Integer do
 			false
 		end
 	end
-	
+
 #	class MultiClassVisitor < RLTK::Visitor
 #		on [Numeric, String] do
 #			:numANDstr
 #		end
-#		
+#
 #		on Array do
 #			:array
 #		end
-#		
+#
 #		on Integer do
 #			:int
 #		end
 #	end
-	
+
 	class NumericVisitor
 		include RLTK::Visitor
-		
+
 		on Numeric do |n|
 			"Numeric: #{n}"
 		end
 	end
-	
+
 	class SubclassVisitor < NumericVisitor
-		
+
 		on Integer do |i|
 			"Integer: #{i}"
 		end
@@ -61,90 +61,90 @@ class VisitorTester < Test::Unit::TestCase
 
 	class SimpleVisitor
 		include RLTK::Visitor
-		
+
 		on Array do |a|
 			a.map { |o| visit o }
 		end
-		
+
 		on Integer do |i|
 			i + 1
 		end
 	end
-	
+
 	class StatefulVisitor
 		include RLTK::Visitor
-		
+
 		def initialize
 			@accumulator = 0
 		end
-		
+
 		on Array do |a|
 			a.each { |o| visit o }
-			
+
 			@accumulator
 		end
-		
+
 		on Integer do |i|
 			@accumulator += i
 		end
 	end
-	
+
 	class WrappingVisitor
 		include RLTK::Visitor
-		
+
 		def foo
 			1
 		end
-		
+
 		def wrapper_fun(o)
 			1 + yield(o, 1)
 		end
-		
-		on Integer, wrapper: :wrapper_fun do |i, other|
+
+		on Integer, :wrapper => :wrapper_fun do |i, other|
 			i + foo + other
 		end
 	end
-	
+
 	def test_guarded_visitor
 		assert( GuardedVisitor.new.visit( 5))
 		assert(!GuardedVisitor.new.visit(11))
 	end
-	
+
 	def test_inheritance
 		v = SubclassVisitor.new
-		
+
 		assert_equal("Numeric: 3.1415296", v.visit(3.1415296))
 		assert_equal("Integer: 42",        v.visit(42))
 	end
-	
+
 #	def test_multiclass
 #		v = MultiClassVisitor.new
-#		
+#
 #		assert_equal(:integer, v.visit(1))
 #		assert_equal(:array,   v.visit([1,2,3]))
-#		
+#
 #		assert_equal(:numANDstr, v.visit(42.0))
 #		assert_equal(:numANDstr, v.visit('42'))
 #	end
-	
+
 	def test_simple_visitor
 		actual	= SimpleVisitor.new.visit([1, 2, 3, 4])
 		expected	= [2, 3, 4, 5]
-		
+
 		assert_equal(expected, actual)
 	end
-	
+
 	def test_stateful_visitor
 		actual	= StatefulVisitor.new.visit([1, 2, 3, 4])
 		expected	= 10
-		
+
 		assert_equal(expected, actual)
 	end
-	
+
 	def test_wrapping
 		actual	= WrappingVisitor.new.visit(39)
 		expected	= 42
-		
+
 		assert_equal(expected, actual)
 	end
 end

--- a/test/ts_rltk.rb
+++ b/test/ts_rltk.rb
@@ -14,7 +14,7 @@ begin
 		add_filter 'tc_*'
 		add_filter 'generated*'
 	end
-	
+
 rescue LoadError
 	puts 'SimpleCov not installed.  Continuing without it.'
 end
@@ -39,11 +39,13 @@ require 'util/ts_util'
 begin
 	class Tester
 		extend FFI::Library
-		
+
 		ffi_lib("LLVM-#{RLTK::LLVM_TARGET_VERSION}")
 	end
-	
+
 	# The test suite for the LLVM bindings
 	require 'cg/ts_cg'
+rescue LoadError
+  puts "Unable to load LLVM #{RLTK::LLVM_TARGET_VERSION}."
 rescue
 end


### PR DESCRIPTION
I'm using RLTK for a project I'm working on which hopes to maintain
compatibility with Ruby 1.8, which necessitated making RLTK work on Ruby
1.8.

Changes:
- Change instances of Ruby 1.9 hash syntax to hashrockets.
- Change instances of Ruby 1.9 stabby to proc keyword.
- Change double splat method arguments to concat + splat.
- Explicitly rescue LoadError when loading the cg test suite.

Caveats:
- I had to disable ParserTester#test_use on 1.8 because the
  inherited hook is called _after_ class definition when using anonymous
  classes on 1.8. This is fixed on >= 1.9.
  (See: http://bugs.ruby-lang.org/issues/4273)
