### PR TITLE
Enable actions to return more than one token.

### DIFF
--- a/lib/rltk/lexer.rb
+++ b/lib/rltk/lexer.rb
@@ -120,12 +120,25 @@ module RLTK # :nodoc:
 						rule = match.last
 					
 						txt = scanner.scan(rule.pattern)
-						type, value = env.rule_exec(rule.pattern.match(txt), txt, &rule.action)
+						results = env.rule_exec(rule.pattern.match(txt), txt, &rule.action)
+                                                result_processor = proc do |result|
+                                                        type, value = result
+
+                                                        if type
+                                                                pos = StreamPosition.new(stream_offset, line_number, line_offset, txt.length, file_name)
+                                                                tokens << Token.new(type, value, pos) 
+                                                        end
+                                                end
 					
-						if type
-							pos = StreamPosition.new(stream_offset, line_number, line_offset, txt.length, file_name)
-							tokens << Token.new(type, value, pos) 
-						end
+                                                if result.is_a? Array
+                                                        if results.all? { |e| e.is_a? Array }
+                                                                results.each(&result_processor)
+                                                        else
+                                                                result_processor.call(results)
+                                                        end
+                                                else
+                                                        result_processor.call(results)
+                                                end
 					
 						# Advance our stat counters.
 						stream_offset += txt.length


### PR DESCRIPTION
Hi Chris.

I'm not sure if you're interested in this, but I wanted to make Lexer actions able to return more than one token.

The language I am parsing is whitespace aware, and I wanted to emit more than one outdent token if required, eg 

```
foo
  bar
    baz
```

should return `:VAR, :INDENT, :VAR, :INDENT, :VAR, :OUTDENT, :OUTDENT` from the lexer.

I did this by patching the lexer to allow the action to return an array of arrays, so instead of 
`[ :OUTDENT, 1 ]` it can return `[[ :OUTDENT 1 ], [ :OUTDENT, 0 ]]`.

Feel free to merge if you think it's useful.
