### PR TITLE
Added attribute readers and fixed remainder in LexingError.

### DIFF
--- a/lib/rltk/lexer.rb
+++ b/lib/rltk/lexer.rb
@@ -148,7 +148,7 @@ module RLTK # :nodoc:
 							line_offset += txt.length()
 						end
 					else
-						error = LexingError.new(stream_offset, line_number, line_offset, scanner.post_match)
+						error = LexingError.new(stream_offset, line_number, line_offset, scanner.rest)
 						raise(error, 'Unable to match string with any of the given rules')
 					end
 				end


### PR DESCRIPTION
The accessors are useful for printing custom error messages. 

I also changed scanner.post_match for scanner.rest. post_match returns nil if there is no valid match before calling it, and rest returns the rest of the string after the scanner pointer.
