### PR TITLE
Add Rubinius compatibility

### DIFF
--- a/lib/rltk/parser.rb
+++ b/lib/rltk/parser.rb
@@ -224,7 +224,7 @@ module RLTK # :nodoc:
 				end
 				
 				# Check the actions in each state.
-				@states.each do |state|
+				each_state do |state|
 					state.actions.each do |sym, actions|
 						if CFG::is_terminal?(sym)
 							# Here we check actions for terminals.
@@ -344,7 +344,7 @@ module RLTK # :nodoc:
 				@token_precs		= nil
 				
 				# Drop the items from each of the states.
-				@states.each { |state| state.clean }
+				each_state { |state| state.clean }
 			end
 			
 			# Set the default argument type for the actions associated with
@@ -450,7 +450,7 @@ module RLTK # :nodoc:
 					io.puts('###############')
 					io.puts
 					
-					@states.each do |state|
+					each_state do |state|
 						io.puts("State #{state.id}:")
 						io.puts
 						
@@ -562,7 +562,7 @@ module RLTK # :nodoc:
 				end
 				
 				# Build the rest of the transition table.
-				@states.each do |state|
+				each_state do |state|
 					#Transition states.
 					tstates = Hash.new { |h,k| h[k] = State.new(@symbols) }
 					
@@ -654,6 +654,17 @@ module RLTK # :nodoc:
 				end
 			end
 			
+			# Iterate over the parser's states.
+			#
+			# @return [void]
+			def each_state
+				current_state = 0
+				while current_state < @states.count
+					yield @states.at(current_state)
+					current_state += 1
+				end
+			end
+			
 			# @return [CFG] The grammar that can be parsed by this Parser.
 			def grammar
 				@grammar.clone
@@ -672,7 +683,7 @@ module RLTK # :nodoc:
 				if not @grammar_prime
 					@grammar_prime = CFG.new
 					
-					@states.each do |state|
+					each_state do |state|
 						state.each do |item|
 							lhs = "#{state.id}_#{item.next_symbol}".to_sym
 							
@@ -1055,7 +1066,7 @@ module RLTK # :nodoc:
 				# If both options are false there is no pruning to do.
 				return if not (do_lookahead or do_precedence)
 				
-				@states.each do |state0|
+				each_state do |state0|
 					
 					#####################
 					# Lookahead Pruning #
@@ -1071,7 +1082,7 @@ module RLTK # :nodoc:
 							lookahead = Array.new
 							
 							# Build the lookahead set.
-							@states.each do |state1|
+							each_state do |state1|
 								if self.check_reachability(state1, state0, production.rhs)
 									lookahead |= self.grammar_prime.follow_set("#{state1.id}_#{production.lhs}".to_sym)
 								end


### PR DESCRIPTION
This pull request adds Rubinius compatibility (fixes issue #19). The only problem that prevented RLTK from running on Rubinus, was the different behavior of `Array#each` in Rubinius. While it is possible to append new elements to the array while enumerating it in MRI, the enumeration would stop after the original number of elements in Rubinus.

This pull request changes the behavior of `RLTK::Parser::State#each` to properly enumerate all items, including those added while enumerating.

Additionally it adds `RLTK::Parser#each_state` to enable the same behavior for the `@states` array.

Please let my know, if you want me to adjust my implementation in any way.

Thanks a lot for the RLTK gem. It's been a pleasure to work with it!
