### PR TITLE
In case of multiline match, chars in the last lines must be taken in account

### DIFF
--- a/lib/rltk/lexer.rb
+++ b/lib/rltk/lexer.rb
@@ -142,7 +142,7 @@ module RLTK
 
 						if (newlines = txt.count("\n")) > 0
 							line_number += newlines
-							line_offset  = 0
+							line_offset = txt.rpartition("\n").last.length
 						else
 							line_offset += txt.length()
 						end


### PR DESCRIPTION
This PR aims to fix https://github.com/chriswailes/RLTK/issues/38.

When computing `line_offset`, the length of the last line must be taken into account as well.