### PR TITLE
Add ability to limit amount of context returned for error message

### DIFF
--- a/lib/rltk/parser.rb
+++ b/lib/rltk/parser.rb
@@ -34,6 +34,16 @@ module RLTK
 	# defined language.
 	class NotInLanguage < StandardError
 
+		class << self
+			def default_context_length
+				@default_context_length || 100
+			end
+
+			def default_context_length=(v)
+				@default_context_length = v
+			end
+		end
+
 		# @return [Array<Token>]  List of tokens that have been successfully parsed
 		attr_reader :seen
 
@@ -46,15 +56,18 @@ module RLTK
 		# @param [Array<Token>]  seen       Tokens that have been successfully parsed
 		# @param [Token]         current    Token that caused the parser to stop
 		# @param [Array<Token>]  remaining  Tokens that have yet to be seen
-		def initialize(seen, current, remaining)
-			@seen      = seen
-			@current   = current
-			@remaining = remaining
+		def initialize(seen, current, remaining, context_length = self.class.default_context_length)
+			@seen           = seen
+			@current        = current
+			@remaining      = remaining
+			@context_length = context_length
 		end
 
 		# @return [String] String representation of the error.
 		def to_s
-			"String not in language.  Token info:\n\tSeen: #{@seen}\n\tCurrent: #{@current}\n\tRemaining: #{@remaining}"
+			seen = @context_length == :all ? @seen : @seen[-@context_length..-1]
+			remaining = @context_length == :all ? @remaining : @remaining[0..@context_length]
+			"String not in language.  Token info:\n\tSeen: #{seen}\n\tCurrent: #{@current}\n\tRemaining: #{remaining}"
 		end
 	end
 


### PR DESCRIPTION
Depending on what I'm parsing, sometimes having several thousand nodes of context in the error message is a pretty large pain in the butt (especially when working over a network connection).  This adds the ability to limit the amount of context the error message returns (defaults to 100 nodes on either side of the current node).