### PR TITLE
Fix tests (limited filigree version)

### DIFF
--- a/rltk.gemspec
+++ b/rltk.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
 	################
 	
 	s.add_dependency('ffi', '>= 1.0.0')
-	s.add_dependency('filigree', '>= 0.2.0')
+    s.add_dependency('filigree', '>= 0.2.0', '< 0.4.0')
 	
 	############################
 	# Development Dependencies #


### PR DESCRIPTION
Using filigree 0.4.0 was breaking tests (and presumably code) on master.  Limit to less than 0.4.0 to fix that :)