### PR TITLE
Replace subclass_of? method

### DIFF
--- a/lib/rltk/ast.rb
+++ b/lib/rltk/ast.rb
@@ -117,7 +117,7 @@ module RLTK
 				end
 
 				# Check to make sure that type is a subclass of ASTNode.
-				if not t.subclass_of?(ASTNode)
+				if not t < ASTNode
 					raise "A child's type specification must be a subclass of ASTNode."
 				end
 

--- a/lib/rltk/cg/type.rb
+++ b/lib/rltk/cg/type.rb
@@ -494,7 +494,7 @@ end
 # @return [Type] The object *o* or an instance of the class passed in parameter *o*.
 def check_cg_type(o, type = RLTK::CG::Type, blame = 'type', strict = false)
 	if o.is_a?(Class)
-		type_ok = if strict then o == type else o.subclass_of?(type) end
+		type_ok = if strict then o == type else o < type end
 
 		if type_ok
 			if o.includes_module?(Singleton)
@@ -529,7 +529,7 @@ end
 def check_cg_array_type(array, type = RLTK::CG::Type, blame = 'el_types', strict = false)
 	array.map do |o|
 		if o.is_a?(Class)
-			type_ok = if strict then o == type else o.subclass_of?(type) end
+			type_ok = if strict then o == type else o < type end
 
 			if type_ok
 				if o.includes_module?(Singleton)


### PR DESCRIPTION
This resolves #54 by removing all uses of `subclass_of?` and replacing it with the module comparison operator `<` which has the same behavior.