### PR TITLE
Fix typo RLKT -> RLTK

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Here are some reasons to use RLTK to build your lexers, parsers, and abstract sy
 
 * **Parser Serialization** - RLTK parsers can be serialized and saved after they are generated for faster loading the next time they are required.
 
-* **Error Productions** - RLKT parsers can use error productions to recover from, and report on, errors.
+* **Error Productions** - RLTK parsers can use error productions to recover from, and report on, errors.
 
 * **Fast Prototyping** - If you need to change your lexer/parser you don't have to re-run the lexer and parser generation tools, simply make the changes and be on your way.
 

--- a/examples/kazoo/chapter 1/Chapter1.md
+++ b/examples/kazoo/chapter 1/Chapter1.md
@@ -2,7 +2,7 @@
 
 When it comes to implementing a language, the first thing needed is the ability to process a text file and recognize what it says.  The traditional way to do this is to use a *lexer* (aka *scanner*) to break the input up into *tokens*.  Each token returned by the lexer includes a token code and potentially some metadata (e.g. the numeric value of a number).
 
-It is pretty simple to create a lexer using RLKT:
+It is pretty simple to create a lexer using RLTK:
 
 ```Ruby
 class Lexer < RLTK::Lexer; end

--- a/lib/rltk/cg/type.rb
+++ b/lib/rltk/cg/type.rb
@@ -172,7 +172,7 @@ module RLTK::CG
 		#
 		# @raise [RuntimeError] This function has no meaning in this class.
 		def value_class
-			raise 'The RLKT::CG::IntType class has no value class.'
+			raise 'The RLTK::CG::IntType class has no value class.'
 		end
 	end
 

--- a/lib/rltk/lexers/calculator.rb
+++ b/lib/rltk/lexers/calculator.rb
@@ -17,7 +17,7 @@ require 'rltk/lexer'
 module RLTK
 
 	# The RLTK::Lexers module contains the lexers that are included as part of
-	# the RLKT project.
+	# the RLTK project.
 	module Lexers
 
 		# The Calculator lexer is a simple lexer for use with several of the

--- a/lib/rltk/parsers/infix_calc.rb
+++ b/lib/rltk/parsers/infix_calc.rb
@@ -17,7 +17,7 @@ require 'rltk/parser'
 module RLTK
 
 	# The RLTK::Parsers module contains the parsers that are included as part
-	# of the RLKT project.
+	# of the RLTK project.
 	module Parsers
 
 		# A parser for a simple infix calculator.


### PR DESCRIPTION
Found this typo reading http://chriswailes.github.io/RLTK/
Then found few other inclusions of the same with grep.
